### PR TITLE
Review/v0.3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Run tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install vcrpy = "^4.0"
+      - name: Run tests
+        run: |
+          python -m unittest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install vcrpy = "^4.0"
+          pip install vcrpy~=4.0
       - name: Run tests
         run: |
           python -m unittest

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 env.yaml
 .env
 .venv
+poetry.lock
 
 # mypy
 .mypy_cache/

--- a/README.md
+++ b/README.md
@@ -2,20 +2,25 @@
 
 [![PyPI](https://img.shields.io/pypi/v/irv-autopkg-client)](https://pypi.org/project/irv-autopkg-client/)
 
-A client library for accessing the irv-autopkg API, currently hosted at [global.infrastructureresilience.org](https://global.infrastructureresilience.org/extract/redoc).
+A client library for accessing the irv-autopkg API, currently hosted at
+[global.infrastructureresilience.org](https://global.infrastructureresilience.org/extract/redoc).
 
-The irv-autopkg service allows users to extract portions of global datasets pertaining to climate risk and resilience. This Python package is a client for communicating with the irv-autopkg API.
+The irv-autopkg service allows users to extract portions of global datasets
+pertaining to climate risk and resilience. This Python package is a client for
+communicating with the irv-autopkg API.
 
 ## Installation
 
 Install from PyPI with:
+
 ```
 pip install irv-autopkg-client
 ```
 
 ## Usage
 
-Create a client object to establish a session
+Create a client object to establish a session:
+
 ```
 import irv_autopkg_client
 client = irv_autopkg_client.Client()
@@ -30,26 +35,31 @@ help(client)
 ## Quick start
 
 Is the API responding?
+
 ```
 client.server_readiness()
 ```
 
 Which boundaries can we create extracts for?
+
 ```
 client.boundary_list()
 ```
 
 Which datasets are available?
+
 ```
 client.dataset_list()
 ```
 
 Get information on a specific dataset:
+
 ```
 client.dataset("wri_aqueduct.version_2")
 ```
 
 To submit an extract job:
+
 ```
 job_id = client.job_submit(
     country_iso,
@@ -61,16 +71,19 @@ job_id = client.job_submit(
 ```
 
 We can then check if the job is complete:
+
 ```
 client.job_complete(job_id)
 ```
 
 Get the boundary of a territory:
+
 ```
 boundary = client.boundary_geometry("bgd")
 ```
 
 Download some extracted data:
+
 ```
 client.extract_download(
     "bgd",

--- a/README.md
+++ b/README.md
@@ -97,9 +97,35 @@ client.extract_download(
 )
 ```
 
+## Development
+
+First clone this repository (currently hosted at
+[nismod/irv-autopkg-client](https://github.com/nismod/irv-autopkg-client.git)).
+
+To install the package in editable mode, run:
+
+```
+pip install -e .
+pip install vcrpy = "^4.0"
+```
+
+Alternatively, if you have [`poetry`](https://python-poetry.org/docs/), run:
+
+```
+poetry install
+```
+
 ## Testing
 
 To run the bundled tests, try:
+
 ```
 python -m unittest
+```
+
+With `poetry`, either work within `poetry shell`, or run single commands in the
+virtual environment:
+
+```
+poetry run python -m unittest
 ```

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To install the package in editable mode, run:
 
 ```
 pip install -e .
-pip install vcrpy = "^4.0"
+pip install vcrpy~=4.0
 ```
 
 Alternatively, if you have [`poetry`](https://python-poetry.org/docs/), run:

--- a/irv_autopkg_client/__init__.py
+++ b/irv_autopkg_client/__init__.py
@@ -6,6 +6,4 @@ from .client import Client
 
 __version__ = "0.3.2"
 
-__all__ = (
-    "Client",
-)
+__all__ = ("Client",)

--- a/irv_autopkg_client/client.py
+++ b/irv_autopkg_client/client.py
@@ -2,7 +2,7 @@ import logging
 import os
 import urllib.parse
 import requests
-from typing import Optional
+from typing import Optional, List, Dict
 
 
 BASE_URL: str = "https://global.infrastructureresilience.org/extract/v1/"
@@ -42,7 +42,7 @@ class Client:
             response = requests.get(url)
             file.write(response.content)
 
-    def request(self, verb: str, route: str, *args, **kwargs) -> dict:
+    def request(self, verb: str, route: str, *args, **kwargs) -> Dict:
         """
         Wrap requests' request and prepend self.base_url to the requested route.
 
@@ -67,7 +67,7 @@ class Client:
 
         return response.json()
 
-    def boundary(self, name: str) -> dict:
+    def boundary(self, name: str) -> Dict:
         """
         Detailed view of a given boundary.
 
@@ -76,7 +76,7 @@ class Client:
         """
         return self.request("GET", f"boundaries/{name}")
 
-    def boundary_geometry(self, name: str) -> dict:
+    def boundary_geometry(self, name: str) -> Dict:
         """
         Boundary geometry.
 
@@ -94,7 +94,7 @@ class Client:
         name: Optional[str] = None,
         latitude: Optional[float] = None,
         longitude: Optional[float] = None,
-    ) -> dict:
+    ) -> Dict:
         """
         Search for a boundary by name or latitude, longitude coordinate pair.
 
@@ -116,13 +116,13 @@ class Client:
 
         return self.request("GET", "boundaries/search", params=query_params)
 
-    def boundary_list(self) -> list:
+    def boundary_list(self) -> List:
         """
         List of available boundaries.
         """
         return self.request("GET", "boundaries")
 
-    def extract(self, boundary_name: str) -> dict:
+    def extract(self, boundary_name: str) -> Dict:
         """
         Details of existing extract.
 
@@ -135,7 +135,7 @@ class Client:
         self,
         boundary_name: str,
         download_dir: str,
-        dataset_filter: Optional[list[str]] = None,
+        dataset_filter: Optional[List[str]] = None,
         overwrite: bool = False,
     ) -> None:
         """
@@ -174,13 +174,13 @@ class Client:
             )
             self.download_file(url, filepath)
 
-    def extract_list(self) -> list:
+    def extract_list(self) -> List:
         """
         List of boundaries with already processed data extracts.
         """
         return self.request("GET", "packages")
 
-    def dataset(self, name_version: str) -> dict:
+    def dataset(self, name_version: str) -> Dict:
         """
         Return details on a given dataset.
 
@@ -198,7 +198,7 @@ class Client:
         ]
         return version
 
-    def dataset_list(self) -> list:
+    def dataset_list(self) -> List:
         """
         List of dataset identifiers available to extract from.
         """
@@ -207,7 +207,7 @@ class Client:
             version["name"] for dataset in response for version in dataset["versions"]
         ]
 
-    def job_submit(self, boundary_name: str, datasets: list[str]) -> str:
+    def job_submit(self, boundary_name: str, datasets: List[str]) -> str:
         """
         Submit a new extract job to the queue. If successfully submitted,
         returns UUID of created job.
@@ -227,7 +227,7 @@ class Client:
         )
         return response["job_id"]
 
-    def job_status(self, uuid: str) -> dict:
+    def job_status(self, uuid: str) -> Dict:
         """
         Information on job.
 

--- a/irv_autopkg_client/client.py
+++ b/irv_autopkg_client/client.py
@@ -4,8 +4,6 @@ import urllib.parse
 import requests
 from typing import Optional
 
-from shapely.geometry import shape
-
 
 BASE_URL: str = "https://global.infrastructureresilience.org/extract/v1/"
 
@@ -78,7 +76,7 @@ class Client:
         """
         return self.request("GET", f"boundaries/{name}")
 
-    def boundary_geometry(self, name: str) -> shape:
+    def boundary_geometry(self, name: str) -> dict:
         """
         Boundary geometry.
 
@@ -86,9 +84,9 @@ class Client:
             name: Identifier for boundary (e.g. 'egy' for Egypt)
 
         Returns:
-            Shapely geometry of boundary
+            dict as GeoJSON/fiona geometry of boundary
         """
-        return shape(self.boundary(name)["geometry"])
+        return self.boundary(name)["geometry"]
 
     def boundary_search(
         self, *, name: Optional[str] = None, latitude: Optional[float] = None, longitude: Optional[float] = None

--- a/irv_autopkg_client/client.py
+++ b/irv_autopkg_client/client.py
@@ -89,7 +89,11 @@ class Client:
         return self.boundary(name)["geometry"]
 
     def boundary_search(
-        self, *, name: Optional[str] = None, latitude: Optional[float] = None, longitude: Optional[float] = None
+        self,
+        *,
+        name: Optional[str] = None,
+        latitude: Optional[float] = None,
+        longitude: Optional[float] = None,
     ) -> dict:
         """
         Search for a boundary by name or latitude, longitude coordinate pair.
@@ -106,7 +110,9 @@ class Client:
             query_params["latitude"] = latitude
             query_params["longitude"] = longitude
         if not query_params:
-            raise RuntimeError("Must specify search kwargs: name or latitude and longitude")
+            raise RuntimeError(
+                "Must specify search kwargs: name or latitude and longitude"
+            )
 
         return self.request("GET", "boundaries/search", params=query_params)
 
@@ -126,7 +132,11 @@ class Client:
         return self.request("GET", f"packages/{boundary_name}")
 
     def extract_download(
-        self, boundary_name: str, download_dir: str, dataset_filter: Optional[list[str]] = None, overwrite: bool = False
+        self,
+        boundary_name: str,
+        download_dir: str,
+        dataset_filter: Optional[list[str]] = None,
+        overwrite: bool = False,
     ) -> None:
         """
         Download the files contained within an extract to a given directory.
@@ -159,7 +169,9 @@ class Client:
                 url_to_file_path[url] = os.path.join(folder_path, filename)
 
         for i, (url, filepath) in enumerate(url_to_file_path.items()):
-            logging.info(f"Downloading {i + 1} of {len(url_to_file_path)} to {filepath}")
+            logging.info(
+                f"Downloading {i + 1} of {len(url_to_file_path)} to {filepath}"
+            )
             self.download_file(url, filepath)
 
     def extract_list(self) -> list:
@@ -179,7 +191,11 @@ class Client:
         name, version = name_version.split(".")
         response = self.request("GET", "processors")
         (dataset,) = [dataset for dataset in response if dataset["name"] == name]
-        (version,) = [version for version in dataset["versions"] if version["name"] == name_version]
+        (version,) = [
+            version
+            for version in dataset["versions"]
+            if version["name"] == name_version
+        ]
         return version
 
     def dataset_list(self) -> list:
@@ -187,7 +203,9 @@ class Client:
         List of dataset identifiers available to extract from.
         """
         response = self.request("GET", "processors")
-        return [version["name"] for dataset in response for version in dataset["versions"]]
+        return [
+            version["name"] for dataset in response for version in dataset["versions"]
+        ]
 
     def job_submit(self, boundary_name: str, datasets: list[str]) -> str:
         """
@@ -202,7 +220,11 @@ class Client:
         Returns:
             Extract job ID
         """
-        response = self.request("POST", "jobs", json={"boundary_name": boundary_name, "processors": datasets})
+        response = self.request(
+            "POST",
+            "jobs",
+            json={"boundary_name": boundary_name, "processors": datasets},
+        )
         return response["job_id"]
 
     def job_status(self, uuid: str) -> dict:

--- a/irv_autopkg_client/tests/test_client.py
+++ b/irv_autopkg_client/tests/test_client.py
@@ -27,34 +27,40 @@ class TestClient(unittest.TestCase):
 
     @vcr.use_cassette()
     def test_boundary(self):
-        expected_keys = set(['name', 'name_long', 'admin_level', 'geometry', 'envelope'])
+        expected_keys = set(
+            ["name", "name_long", "admin_level", "geometry", "envelope"]
+        )
         assert expected_keys == set(self.client.boundary("vat").keys())
 
     @vcr.use_cassette()
     def test_boundary_geometry(self):
         vatican_geojson = {
             "type": "MultiPolygon",
-            "coordinates": [[[
-                [12.453136917, 41.902751941],
-                [12.452714082, 41.903016213],
-                [12.452766936, 41.903439049],
-                [12.453031208, 41.903914738],
-                [12.453982588, 41.903861884],
-                [12.454035442, 41.902751941],
-                [12.453136917, 41.902751941]
-            ]]]
+            "coordinates": [
+                [
+                    [
+                        [12.453136917, 41.902751941],
+                        [12.452714082, 41.903016213],
+                        [12.452766936, 41.903439049],
+                        [12.453031208, 41.903914738],
+                        [12.453982588, 41.903861884],
+                        [12.454035442, 41.902751941],
+                        [12.453136917, 41.902751941],
+                    ]
+                ]
+            ],
         }
         geom = self.client.boundary_geometry("vat")
         assert vatican_geojson == geom
 
     @vcr.use_cassette()
     def test_boundary_search_by_coordinates(self):
-        expected = [{'name': 'gbr', 'name_long': 'United Kingdom'}]
+        expected = [{"name": "gbr", "name_long": "United Kingdom"}]
         assert expected == self.client.boundary_search(longitude=-1, latitude=52)
 
     @vcr.use_cassette()
     def test_boundary_search_by_name(self):
-        expected = [{'name': 'gbr', 'name_long': 'United Kingdom'}]
+        expected = [{"name": "gbr", "name_long": "United Kingdom"}]
         assert expected == self.client.boundary_search(name="united kingdom")
 
     @vcr.use_cassette()
@@ -72,7 +78,9 @@ class TestClient(unittest.TestCase):
 
     @vcr.use_cassette()
     def test_extract(self):
-        expected_keys = set(['boundary_name', 'uri', 'boundary', 'processors', 'datapackage'])
+        expected_keys = set(
+            ["boundary_name", "uri", "boundary", "processors", "datapackage"]
+        )
         assert expected_keys == self.client.extract("mar").keys()
 
     @vcr.use_cassette()
@@ -87,12 +95,25 @@ class TestClient(unittest.TestCase):
     def test_dataset(self):
         expected_keys = set(
             [
-                'name', 'description', 'version', 'status', 'uri', 'data_author',
-                'data_title', 'data_title_long', 'data_summary', 'data_citation',
-                'data_license', 'data_origin_url', 'data_formats'
+                "name",
+                "description",
+                "version",
+                "status",
+                "uri",
+                "data_author",
+                "data_title",
+                "data_title_long",
+                "data_summary",
+                "data_citation",
+                "data_license",
+                "data_origin_url",
+                "data_formats",
             ]
         )
-        assert expected_keys == self.client.dataset("gri_osm.roads_and_rail_version_1").keys()
+        assert (
+            expected_keys
+            == self.client.dataset("gri_osm.roads_and_rail_version_1").keys()
+        )
 
     @vcr.use_cassette()
     def test_dataset_list(self):

--- a/irv_autopkg_client/tests/test_client.py
+++ b/irv_autopkg_client/tests/test_client.py
@@ -1,6 +1,5 @@
 import unittest
 
-import shapely
 import vcr
 
 from irv_autopkg_client import Client
@@ -33,14 +32,20 @@ class TestClient(unittest.TestCase):
 
     @vcr.use_cassette()
     def test_boundary_geometry(self):
-        vatican_wkt = (
-            "MULTIPOLYGON (((12.453136917 41.902751941, "
-            "12.452714082 41.903016213, 12.452766936 41.903439049, "
-            "12.453031208 41.903914738, 12.453982588 41.903861884, "
-            "12.454035442 41.902751941, 12.453136917 41.902751941)))"
-        )
+        vatican_geojson = {
+            "type": "MultiPolygon",
+            "coordinates": [[[
+                [12.453136917, 41.902751941],
+                [12.452714082, 41.903016213],
+                [12.452766936, 41.903439049],
+                [12.453031208, 41.903914738],
+                [12.453982588, 41.903861884],
+                [12.454035442, 41.902751941],
+                [12.453136917, 41.902751941]
+            ]]]
+        }
         geom = self.client.boundary_geometry("vat")
-        assert shapely.from_wkt(vatican_wkt) == geom
+        assert vatican_geojson == geom
 
     @vcr.use_cassette()
     def test_boundary_search_by_coordinates(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ python = "^3.7"
 requests = "^2.28"
 
 [tool.poetry.group.test.dependencies]
-vcr = "^4.0"
+vcrpy = "^4.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.7"
 requests = "^2.28"
-shapely = "^2.0"
 
 [tool.poetry.group.test.dependencies]
 vcr = "^4.0"


### PR DESCRIPTION
One larger thing - suggest dropping the dependency on `shapely` - it's a relatively big and hard-to-install library to require just for the `boundary_geometry` call; anyone who actually needs to work with the shape can install it - e.g. in the `irv-autopkg-use` environment.

Small things:
- format fixes, running the lot through `black` for consistency
- added a few development install notes
- fix `vcr` => `vcrpy` for pip/poetry install
- got the CI running - caught an error in 3.7 where typing.List/Dict are needed if you want to use a subscript in the type declaration (like `List[str]`)
